### PR TITLE
Adding the ubuntu wildcard domain to egress rules list

### DIFF
--- a/app-fqdn-rules.tf
+++ b/app-fqdn-rules.tf
@@ -4,6 +4,7 @@ locals {
     tcp = {
       "*.aviatrix.com" = "443"
       "aviatrix.com"   = "80"
+      "*.ubuntu.com"   = "80"
     }
     udp = {
       "dns.google.com" = "53"

--- a/app-fqdn-rules.tf
+++ b/app-fqdn-rules.tf
@@ -4,7 +4,6 @@ locals {
     tcp = {
       "*.aviatrix.com"     = "443"
       "aviatrix.com"       = "80"
-      "*.ubuntu.com"       = "80"
       "*.cloud.google.com" = "443"
       "*.aws.amazon.com"   = "443"
       "*.ubuntu.com"       = "80"


### PR DESCRIPTION
Adding "*.ubuntu.com"  to the rules list to allow the updates and the upgrades of the Linux endpoints.

Will have to run the commands below from the Linux boxes: 

sudo apt-get updates -y
sudo apt-get upgrade -y

Please review the change and allow. Do not hesitate to reach out to the DevOps team if you have any questions regarding the rule added.

## Description

_Describe the changes needed_
